### PR TITLE
Fix HAVE_DIRENT_H test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,13 +48,10 @@ endif()
 find_package(m)
 
 include(CheckSymbolExists)
-include(CheckIncludeFile)
+include(CheckIncludeFileCXX)
 check_symbol_exists(strcasecmp "strings.h" HAVE_DECL_STRCASECMP)
 check_symbol_exists(strncasecmp "strings.h" HAVE_DECL_STRNCASECMP)
-#check_include_file("dirent.h" HAVE_DIRENT_H)
-
-set(HAVE_DIRENT_H True)
-
+check_include_file_cxx("dirent.h" HAVE_DIRENT_H)
 
 string(CONCAT WINDOWS_RC_VERSION "${PROJECT_VERSION_MAJOR}, "
     "${PROJECT_VERSION_MINOR}, ${PROJECT_VERSION_PATCH}, 0")


### PR DESCRIPTION
During the first stream, Jason hacked around the fact that check_include_file only works for C and not C++. This is the real fix for this issue.